### PR TITLE
Keep users forecast locations unique

### DIFF
--- a/server/routes/forecastLocations.router.js
+++ b/server/routes/forecastLocations.router.js
@@ -82,6 +82,47 @@ router.get("/:searchTerm", rejectUnauthenticated, (req, res) => {
 })
 
 
+// POST route to add a new location to the user's list
+// of tracked stations
+router.post("/add-station", rejectUnauthenticated, (req, res) => {
+
+  // Get the specific user and the new station ID
+  const userId = req.user.id
+  const stationId = req.body.stationId
+
+  // Create the SQL query
+  const sqlQuery = `
+    INSERT INTO "user_forecast_locations"
+      ("user_id", "location_id")
+    VALUES
+      ($1, $2);
+  `
+
+  // Create the SQL params array
+  const sqlParams = [
+    userId,
+    stationId,
+  ]
+
+  // Send the request to the DB
+  pool.query(sqlQuery, sqlParams)
+  .then(() => res.sendStatus(201))
+  .catch((err) => {
+
+    // If the record already exists, then just send a 200 response
+    if (err.detail === `Key (user_id, location_id)=(${userId}, ${stationId}) already exists.`) {
+      res.sendStatus(200)
+    }
+    // Otherwise, an error has occurred, so log it
+    else {
+      console.log(`Error in forecastLocations "/add-station" POST with ${err}`)
+      res.sendStatus(500)
+    }
+  })
+
+})
+
+
 // DELETE route to remove a location from the user's stored
 // location list
 router.delete("/:id", rejectUnauthenticated, (req, res) => {

--- a/src/components/ForecastLocations/SetForecastLocations/ListSearchedForecastLocation.jsx
+++ b/src/components/ForecastLocations/SetForecastLocations/ListSearchedForecastLocation.jsx
@@ -1,9 +1,30 @@
+// Import the core libraries and functions
+import { useDispatch } from "react-redux"
+
+// Component that displays the search results from the list
+// of available stations in the database. Allows users to
+// add stations to their tracked list
 export default function ListSearchedForecastLocation({ searchItem }) {
 
-    return (
-        <div>
-            <p>{searchItem.station}</p>
-            <p>{searchItem.name} - {searchItem.state}</p>
-        </div>
-    )
+  // Initialize the dispatch function
+  const dispatch = useDispatch()
+
+  // Function that dispatches the selected station
+  // and adds it to the user's tracked list of weather stations
+  const setStationToUserList = () => {
+    dispatch({
+      type: "ADD_STATION_TO_USER_STATION_LIST",
+      payload: {
+        stationId: searchItem.id
+      },
+    })
+  }
+
+  return (
+    <div>
+      <button type="button" onClick={setStationToUserList}>Add</button>
+      <p>{searchItem.station}</p>
+      <p>{searchItem.name} - {searchItem.state}</p>
+    </div>
+  )
 }

--- a/src/redux/sagas/forecastLocations.saga.js
+++ b/src/redux/sagas/forecastLocations.saga.js
@@ -3,6 +3,34 @@ import axios from "axios"
 import { put, takeLatest } from "redux-saga/effects"
 
 
+// Function that adds a station to the user's tracked
+// list
+function* addStationToUserStationList(action) {
+
+  console.log("ADD STATION", action)
+
+  // Build the headers to send along with the server request
+  try {
+    const config = {
+      headers: { 'Content-Type': 'application/json' },
+      withCredentials: true,
+    }
+
+    // Send the POST request to the server
+    yield axios.post('/api/forecast-locations/add-station', action.payload, config)
+
+
+    // Update the user's station list
+    yield put({
+      type: 'GET_USER_FORECAST_LOCATION_LIST',
+    })
+
+  // If errors occur, log them to the console
+  } catch (err) {
+    console.log(`Error with addStationToUserStationList POST: ${err}`)
+  }
+}
+
 // Function that handles getting the user's tracked
 // locations form the server
 function* getUserForecastLocationList() {
@@ -37,8 +65,6 @@ function* getUserForecastLocationList() {
 // user's stored location DB table
 function* removeUserForecastLocation(action) {
 
-  console.log(">>>>>>>>>>>>>", action)
-
   // Build the headers to send along with the server request
   try {
     const config = {
@@ -64,6 +90,7 @@ function* removeUserForecastLocation(action) {
 
 // Get the user's forecast location array from the server
 function* userForecastLocations() {
+  yield takeLatest("ADD_STATION_TO_USER_STATION_LIST", addStationToUserStationList)
   yield takeLatest("GET_USER_FORECAST_LOCATION_LIST", getUserForecastLocationList)
   yield takeLatest("REMOVE_USER_FORECAST_STATION", removeUserForecastLocation)
 }


### PR DESCRIPTION
If a unique pair of `userId` and `locationId` exist in the forecast locations table, then don't send back an error, but instead send a 200 status.