### PR TITLE
Nested the forecast history list elements properly

### DIFF
--- a/src/components/ForecastHistory/DisplayForecastHistory.jsx
+++ b/src/components/ForecastHistory/DisplayForecastHistory.jsx
@@ -2,10 +2,20 @@
 import moment from "moment"
 import { useSelector } from "react-redux"
 
+// Import the used components
+import NestedForecastHistory from "./NestedForecastHistory"
+
 
 // Component that displays the forecast history for the
-// various dates
-export default function DisplayForecastHistory({ forecastHistoryObj }) {
+// various dates.
+//
+// Takes in the current `forecastHistoryObj` that will be
+// rendered to the DOM.
+// If an array of forecast history objects is passed in via
+// the `additionalForecastHistoryArray` param, that will
+// be processed within the containing `<li>` element that
+// will keep all the dates together.
+export default function DisplayForecastHistory({ forecastHistoryObj, additionalForecastHistoryArray }) {
 
   // Get the cloud cover STORE values from REDUX
   const cloudCoverList = useSelector(store => store.config.cloudCover)
@@ -92,6 +102,13 @@ export default function DisplayForecastHistory({ forecastHistoryObj }) {
       <div>
         {forecastCreationDate}
       </div>
+      {(additionalForecastHistoryArray) ?
+        <NestedForecastHistory
+          forecastHistoryArray={additionalForecastHistoryArray}
+        />
+        :
+        null
+      }
     </li>
   )
 }

--- a/src/components/ForecastHistory/ForecastDayComponent.jsx
+++ b/src/components/ForecastHistory/ForecastDayComponent.jsx
@@ -1,0 +1,26 @@
+// Import the used components
+import DisplayForecastHistory from "./DisplayForecastHistory"
+
+
+// Component that takes in the array of historical forecasts
+// for a specific date.
+//
+// The first element of that array is seperated off and displayed
+// as a top-level `<ul>` item. All other objects in that array
+// are kept together and send along to the `<DisplayForecastHistory />`
+// as a parameter for further logic / processing.
+export default function ForecastDayComponent({ forecastHistoryArray }) {
+
+  // Split off the first array from the others.
+  // The top level array is the main object to show in the list.
+  // All other objects in the array will be nested elements.
+  const [primaryForecastHistoryObj, ...otherForecastHistoryArray] = forecastHistoryArray
+
+  return (
+    <DisplayForecastHistory
+      key={primaryForecastHistoryObj.id}
+      forecastHistoryObj={primaryForecastHistoryObj}
+      additionalForecastHistoryArray={otherForecastHistoryArray}
+    />
+  )
+}

--- a/src/components/ForecastHistory/ForecastHistory.jsx
+++ b/src/components/ForecastHistory/ForecastHistory.jsx
@@ -3,8 +3,7 @@ import { useEffect } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 // Import the used components
-import DisplayForecastHistory from "./DisplayForecastHistory"
-import NestedForecastHistory from "./NestedForecastHistory"
+import ForecastDayComponent from "./ForecastDayComponent"
 
 
 // Component that shows the forecast history of the
@@ -43,32 +42,19 @@ export default function ForecastHistory() {
     )
   )
 
-  nestedForecastHistoryArray.map(forecastDateArray => {
-    console.log(forecastDateArray[0])
-  })
 
-
-  // Build the DOM elements
+  // Build the DOM elements by sending one day's array filled with forecast
+  // history objects. Each day will be processed within the top-level
+  // `<ul>` element.
   return (
     <section>
       <ul>
-        {nestedForecastHistoryArray.map(forecastDateArr => {
-          // Split off the first element, but retain the others
-          let [first, ...others] = forecastDateArr
-
-          // Build the DOM elements from that separated list
-          return (
-          <>
-            <DisplayForecastHistory
-              key={first.id}
-              forecastHistoryObj={first}  
-            />
-            <NestedForecastHistory
-              forecastHistoryArray={others}
-            />
-          </>
-          )
-        })}
+        {nestedForecastHistoryArray.map(forecastHistoryArray => 
+          <ForecastDayComponent
+            key={forecastHistoryArray[0].forecast_for_date}
+            forecastHistoryArray={forecastHistoryArray}
+          />
+        )}
       </ul>
     </section>
   )

--- a/src/components/ForecastHistory/NestedForecastHistory.jsx
+++ b/src/components/ForecastHistory/NestedForecastHistory.jsx
@@ -14,7 +14,8 @@ export default function NestedForecastHistory({ forecastHistoryArray }) {
         {forecastHistoryArray.map(forecastHistoryObj => (
           <DisplayForecastHistory
             key={forecastHistoryObj.id}
-            forecastHistoryObj={forecastHistoryObj}  
+            forecastHistoryObj={forecastHistoryObj}
+            additionalForecastHistoryArray={[]}
           />
         ))}
       </ul>

--- a/src/components/ForecastLocations/ListForecastLocations/GetForecastLocations.jsx
+++ b/src/components/ForecastLocations/ListForecastLocations/GetForecastLocations.jsx
@@ -21,9 +21,9 @@ export default function GetForecastLocations() {
     })
   }, [])
 
+  // Get a list of the current user's forecast locations from
+  // the REDUX store
   const userForecastLocations = useSelector(store => store.forecastLocations.userForecastLocationList)
-
-  console.log(">>>>>>>>>>>.", userForecastLocations)
 
 
   // Build the DOM elements


### PR DESCRIPTION
Moved the nested `<ul>` items for a forecast history line item to now be contained __WITHIN__ the parent `<li>` item.

Needed to create a new component to help organize the logic.

The `<DisplayForecastHistory />` component has the potential for an infinite loop, but as long as it is nested within the `if` check it works as intended.