### PR TITLE
Show past forecasts for location and date and allows users to click i…

### DIFF
--- a/public/images/cloud_icons/clear.svg
+++ b/public/images/cloud_icons/clear.svg
@@ -1,0 +1,17 @@
+<svg width="136" height="136" viewBox="0 0 136 136" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_321)">
+<path d="M68 0L79.0125 8.63663L92.4917 4.87171L99.3608 17.0652L113.255 18.7452L114.935 32.6392L127.128 39.5083L123.363 52.9875L132 64L123.363 75.0125L127.128 88.4917L114.935 95.3608L113.255 109.255L99.3608 110.935L92.4917 123.128L79.0125 119.363L68 128L56.9875 119.363L43.5083 123.128L36.6392 110.935L22.7452 109.255L21.0652 95.3608L8.87171 88.4917L12.6366 75.0125L4 64L12.6366 52.9875L8.87171 39.5083L21.0652 32.6392L22.7452 18.7452L36.6392 17.0652L43.5083 4.87171L56.9875 8.63663L68 0Z" fill="#FFD43E"/>
+</g>
+<defs>
+<filter id="filter0_d_71_321" x="0" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_321"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_321" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/cloudy-rain.svg
+++ b/public/images/cloud_icons/cloudy-rain.svg
@@ -1,0 +1,76 @@
+<svg width="216" height="201" viewBox="0 0 216 201" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_290)">
+<circle cx="148.28" cy="26.174" r="25.4882" fill="#DFDFDF"/>
+<circle cx="147.101" cy="27.3529" r="25.4882" fill="white"/>
+<circle cx="183.829" cy="49.65" r="28.1711" fill="#DFDFDF"/>
+<circle cx="182.65" cy="50.8289" r="28.1711" fill="white"/>
+<rect x="127.121" y="47.8776" width="54.2284" height="30.8541" fill="white"/>
+<circle cx="121.842" cy="49.2316" r="28.8419" fill="#DFDFDF"/>
+<circle cx="122.954" cy="50.1581" r="28.8419" fill="white"/>
+</g>
+<g filter="url(#filter1_d_71_290)">
+<circle cx="61.8631" cy="31.3623" r="26.3623" fill="#DFDFDF"/>
+<circle cx="60.6438" cy="32.5816" r="26.3623" fill="white"/>
+<circle cx="98.6316" cy="55.6434" r="29.1373" fill="#DFDFDF"/>
+<circle cx="97.4123" cy="56.8627" r="29.1373" fill="white"/>
+<rect x="39.9786" y="53.8102" width="56.0882" height="31.9123" fill="white"/>
+<circle cx="34.5187" cy="55.2106" r="29.831" fill="#DFDFDF"/>
+<circle cx="35.669" cy="56.169" r="29.831" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_290)">
+<circle cx="113.598" cy="72.8994" r="33.4529" fill="#DFDFDF"/>
+<circle cx="112.82" cy="74.4467" r="33.4529" fill="white"/>
+<circle cx="161.026" cy="103.711" r="36.9743" fill="#DFDFDF"/>
+<circle cx="159.478" cy="105.259" r="36.9743" fill="white"/>
+<rect x="86.597" y="101.385" width="71.1741" height="40.4956" fill="white"/>
+<circle cx="80.3546" cy="102.831" r="37.8546" fill="#DFDFDF"/>
+<circle cx="81.1282" cy="104.378" r="37.8546" fill="white"/>
+<g filter="url(#filter3_d_71_290)">
+<rect width="8.08955" height="33.9619" transform="matrix(0.866206 -0.499686 0.500314 0.865844 147.001 148.542)" fill="#28AFE9"/>
+<rect width="8.08955" height="33.9619" transform="matrix(0.866206 -0.499686 0.500314 0.865844 124.346 163.094)" fill="#28AFE9"/>
+<rect width="8.08955" height="33.9619" transform="matrix(0.866338 -0.499459 0.500541 0.865713 90.5 152.029)" fill="#28AFE9"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_71_290" x="89" y="0.685852" width="127" height="86.3141" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+<filter id="filter1_d_71_290" x="0.68766" y="5" width="131.081" height="89" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+<filter id="filter2_d_71_290" x="38.5" y="39.4465" width="163.5" height="161.053" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+<filter id="filter3_d_71_290" x="86.5" y="144.5" width="88.5" height="56" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/cloudy.svg
+++ b/public/images/cloud_icons/cloudy.svg
@@ -1,0 +1,61 @@
+<svg width="216" height="151" viewBox="0 0 216 151" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_290)">
+<circle cx="148.28" cy="26.174" r="25.4882" fill="#DFDFDF"/>
+<circle cx="147.101" cy="27.3529" r="25.4882" fill="white"/>
+<circle cx="183.829" cy="49.65" r="28.1711" fill="#DFDFDF"/>
+<circle cx="182.65" cy="50.8289" r="28.1711" fill="white"/>
+<rect x="127.121" y="47.8776" width="54.2284" height="30.8541" fill="white"/>
+<circle cx="121.842" cy="49.2316" r="28.8419" fill="#DFDFDF"/>
+<circle cx="122.954" cy="50.1581" r="28.8419" fill="white"/>
+</g>
+<g filter="url(#filter1_d_71_290)">
+<circle cx="61.8631" cy="31.3623" r="26.3623" fill="#DFDFDF"/>
+<circle cx="60.6438" cy="32.5816" r="26.3623" fill="white"/>
+<circle cx="98.6316" cy="55.6434" r="29.1373" fill="#DFDFDF"/>
+<circle cx="97.4123" cy="56.8627" r="29.1373" fill="white"/>
+<rect x="39.9786" y="53.8102" width="56.0882" height="31.9123" fill="white"/>
+<circle cx="34.5187" cy="55.2106" r="29.831" fill="#DFDFDF"/>
+<circle cx="35.669" cy="56.169" r="29.831" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_290)">
+<circle cx="113.598" cy="72.8994" r="33.4529" fill="#DFDFDF"/>
+<circle cx="112.82" cy="74.4467" r="33.4529" fill="white"/>
+<circle cx="161.026" cy="103.711" r="36.9743" fill="#DFDFDF"/>
+<circle cx="159.478" cy="105.259" r="36.9743" fill="white"/>
+<rect x="86.597" y="101.385" width="71.1741" height="40.4956" fill="white"/>
+<circle cx="80.3546" cy="102.831" r="37.8546" fill="#DFDFDF"/>
+<circle cx="81.1282" cy="104.378" r="37.8546" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_71_290" x="89" y="0.685852" width="127" height="86.3141" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+<filter id="filter1_d_71_290" x="0.68766" y="5" width="131.081" height="89" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+<filter id="filter2_d_71_290" x="38.5" y="39.4465" width="163.5" height="110.786" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_290"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_290" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/mostly-clear-light-rain-am.svg
+++ b/public/images/cloud_icons/mostly-clear-light-rain-am.svg
@@ -1,0 +1,70 @@
+<svg width="185" height="170" viewBox="0 0 185 170" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_222)">
+<path d="M109 0L120.012 8.63663L133.492 4.87171L140.361 17.0652L154.255 18.7452L155.935 32.6392L168.128 39.5083L164.363 52.9875L173 64L164.363 75.0125L168.128 88.4917L155.935 95.3608L154.255 109.255L140.361 110.935L133.492 123.128L120.012 119.363L109 128L97.9875 119.363L84.5083 123.128L77.6392 110.935L63.7452 109.255L62.0652 95.3608L49.8717 88.4917L53.6366 75.0125L45 64L53.6366 52.9875L49.8717 39.5083L62.0652 32.6392L63.7452 18.7452L77.6392 17.0652L84.5083 4.87171L97.9875 8.63663L109 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_222)">
+<rect x="67" y="134.5" width="5" height="21" transform="rotate(-30 67 134.5)" fill="#28AFE9"/>
+<rect x="53" y="143.5" width="5" height="21" transform="rotate(-30 53 143.5)" fill="#28AFE9"/>
+<rect x="32.085" y="136.657" width="5" height="21" transform="rotate(-30 32.085 136.657)" fill="#28AFE9"/>
+</g>
+<g filter="url(#filter2_d_71_222)">
+<circle cx="50.4507" cy="83.1897" r="21.6207" fill="#DFDFDF"/>
+<circle cx="49.9483" cy="84.1897" r="21.6207" fill="white"/>
+<circle cx="81.1034" cy="103.103" r="23.8966" fill="#DFDFDF"/>
+<circle cx="80.1034" cy="104.103" r="23.8966" fill="white"/>
+<rect x="33" y="101.6" width="46" height="26.1724" fill="white"/>
+<circle cx="28.9655" cy="102.534" r="24.4655" fill="#DFDFDF"/>
+<circle cx="29.4655" cy="103.534" r="24.4655" fill="white"/>
+</g>
+<g filter="url(#filter3_d_71_222)">
+<circle cx="152.353" cy="71.2505" r="11.459" fill="#DFDFDF"/>
+<circle cx="151.823" cy="71.7805" r="11.459" fill="white"/>
+<circle cx="168.335" cy="81.8048" r="12.6652" fill="#DFDFDF"/>
+<circle cx="167.805" cy="82.3348" r="12.6652" fill="white"/>
+<rect x="142.84" y="81.008" width="24.38" height="13.8714" fill="white"/>
+<circle cx="140.467" cy="81.6167" r="12.9667" fill="#DFDFDF"/>
+<circle cx="140.967" cy="82.0333" r="12.9667" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_71_222" x="41" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter1_d_71_222" x="28.085" y="132" width="57.7452" height="37.6865" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter2_d_71_222" x="0.5" y="61.569" width="108.5" height="74.431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter3_d_71_222" x="123.5" y="59.7916" width="61.5" height="43.2085" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/mostly-clear.svg
+++ b/public/images/cloud_icons/mostly-clear.svg
@@ -1,0 +1,55 @@
+<svg width="185" height="136" viewBox="0 0 185 136" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_222)">
+<path d="M109 0L120.012 8.63663L133.492 4.87171L140.361 17.0652L154.255 18.7452L155.935 32.6392L168.128 39.5083L164.363 52.9875L173 64L164.363 75.0125L168.128 88.4917L155.935 95.3608L154.255 109.255L140.361 110.935L133.492 123.128L120.012 119.363L109 128L97.9875 119.363L84.5083 123.128L77.6392 110.935L63.7452 109.255L62.0652 95.3608L49.8717 88.4917L53.6366 75.0125L45 64L53.6366 52.9875L49.8717 39.5083L62.0652 32.6392L63.7452 18.7452L77.6392 17.0652L84.5083 4.87171L97.9875 8.63663L109 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_222)">
+<circle cx="50.4507" cy="83.1897" r="21.6207" fill="#DFDFDF"/>
+<circle cx="49.9483" cy="84.1897" r="21.6207" fill="white"/>
+<circle cx="81.1034" cy="103.103" r="23.8966" fill="#DFDFDF"/>
+<circle cx="80.1034" cy="104.103" r="23.8966" fill="white"/>
+<rect x="33" y="101.6" width="46" height="26.1724" fill="white"/>
+<circle cx="28.9655" cy="102.534" r="24.4655" fill="#DFDFDF"/>
+<circle cx="29.4655" cy="103.534" r="24.4655" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_222)">
+<circle cx="152.353" cy="71.2505" r="11.459" fill="#DFDFDF"/>
+<circle cx="151.823" cy="71.7805" r="11.459" fill="white"/>
+<circle cx="168.335" cy="81.8048" r="12.6652" fill="#DFDFDF"/>
+<circle cx="167.805" cy="82.3348" r="12.6652" fill="white"/>
+<rect x="142.84" y="81.008" width="24.38" height="13.8714" fill="white"/>
+<circle cx="140.467" cy="81.6167" r="12.9667" fill="#DFDFDF"/>
+<circle cx="140.967" cy="82.0333" r="12.9667" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_71_222" x="41" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter1_d_71_222" x="0.5" y="61.569" width="108.5" height="74.431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter2_d_71_222" x="123.5" y="59.7916" width="61.5" height="43.2085" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/mostly-cloudy-rain.svg
+++ b/public/images/cloud_icons/mostly-cloudy-rain.svg
@@ -1,0 +1,89 @@
+<svg width="216" height="191" viewBox="0 0 216 191" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_259)">
+<path d="M117 0L128.012 8.63663L141.492 4.87171L148.361 17.0652L162.255 18.7452L163.935 32.6392L176.128 39.5083L172.363 52.9875L181 64L172.363 75.0125L176.128 88.4917L163.935 95.3608L162.255 109.255L148.361 110.935L141.492 123.128L128.012 119.363L117 128L105.988 119.363L92.5083 123.128L85.6392 110.935L71.7452 109.255L70.0652 95.3608L57.8717 88.4917L61.6366 75.0125L53 64L61.6366 52.9875L57.8717 39.5083L70.0652 32.6392L71.7452 18.7452L85.6392 17.0652L92.5083 4.87171L105.988 8.63663L117 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_259)">
+<circle cx="161.554" cy="21.1786" r="20.1786" fill="#DFDFDF"/>
+<circle cx="160.62" cy="22.1118" r="20.1786" fill="white"/>
+<circle cx="189.697" cy="39.7641" r="22.3026" fill="#DFDFDF"/>
+<circle cx="188.764" cy="40.6974" r="22.3026" fill="white"/>
+<rect x="144.803" y="38.3609" width="42.9317" height="24.4267" fill="white"/>
+<circle cx="140.623" cy="39.4328" r="22.8336" fill="#DFDFDF"/>
+<circle cx="141.504" cy="40.1664" r="22.8336" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_259)">
+<circle cx="53.3927" cy="23.4568" r="22.4568" fill="#DFDFDF"/>
+<circle cx="52.354" cy="24.4955" r="22.4568" fill="white"/>
+<circle cx="84.714" cy="44.1407" r="24.8207" fill="#DFDFDF"/>
+<circle cx="83.6753" cy="45.1793" r="24.8207" fill="white"/>
+<rect x="34.7503" y="42.5791" width="47.7789" height="27.1845" fill="white"/>
+<circle cx="30.0993" cy="43.772" r="25.4116" fill="#DFDFDF"/>
+<circle cx="31.0792" cy="44.5884" r="25.4116" fill="white"/>
+</g>
+<g filter="url(#filter3_d_71_259)">
+<circle cx="113.598" cy="62.8994" r="33.4529" fill="#DFDFDF"/>
+<circle cx="112.82" cy="64.4467" r="33.4529" fill="white"/>
+<circle cx="161.026" cy="93.7113" r="36.9743" fill="#DFDFDF"/>
+<circle cx="159.478" cy="95.2586" r="36.9743" fill="white"/>
+<rect x="86.597" y="91.3851" width="71.1741" height="40.4956" fill="white"/>
+<circle cx="80.3546" cy="92.831" r="37.8546" fill="#DFDFDF"/>
+<circle cx="81.1282" cy="94.3783" r="37.8546" fill="white"/>
+<g filter="url(#filter4_d_71_259)">
+<rect x="146.964" y="138.665" width="8.09615" height="34.0038" transform="rotate(-30 146.964 138.665)" fill="#28AFE9"/>
+<rect x="124.295" y="153.238" width="8.09615" height="34.0038" transform="rotate(-30 124.295 153.238)" fill="#28AFE9"/>
+<rect x="90.4285" y="142.158" width="8.09615" height="34.0038" transform="rotate(-30 90.4285 142.158)" fill="#28AFE9"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_71_259" x="49" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter1_d_71_259" x="113.79" y="1" width="102.21" height="70" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter2_d_71_259" x="0.68766" y="1" width="112.847" height="77" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter3_d_71_259" x="38.5" y="29.4465" width="163.5" height="161.24" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter4_d_71_259" x="86.4285" y="134.617" width="88.5489" height="56.0693" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/mostly-cloudy.svg
+++ b/public/images/cloud_icons/mostly-cloudy.svg
@@ -1,0 +1,74 @@
+<svg width="216" height="141" viewBox="0 0 216 141" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_259)">
+<path d="M117 0L128.012 8.63663L141.492 4.87171L148.361 17.0652L162.255 18.7452L163.935 32.6392L176.128 39.5083L172.363 52.9875L181 64L172.363 75.0125L176.128 88.4917L163.935 95.3608L162.255 109.255L148.361 110.935L141.492 123.128L128.012 119.363L117 128L105.988 119.363L92.5083 123.128L85.6392 110.935L71.7452 109.255L70.0652 95.3608L57.8717 88.4917L61.6366 75.0125L53 64L61.6366 52.9875L57.8717 39.5083L70.0652 32.6392L71.7452 18.7452L85.6392 17.0652L92.5083 4.87171L105.988 8.63663L117 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_259)">
+<circle cx="161.554" cy="21.1786" r="20.1786" fill="#DFDFDF"/>
+<circle cx="160.62" cy="22.1118" r="20.1786" fill="white"/>
+<circle cx="189.697" cy="39.7641" r="22.3026" fill="#DFDFDF"/>
+<circle cx="188.764" cy="40.6974" r="22.3026" fill="white"/>
+<rect x="144.803" y="38.3609" width="42.9317" height="24.4267" fill="white"/>
+<circle cx="140.623" cy="39.4328" r="22.8336" fill="#DFDFDF"/>
+<circle cx="141.504" cy="40.1664" r="22.8336" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_259)">
+<circle cx="53.3927" cy="23.4568" r="22.4568" fill="#DFDFDF"/>
+<circle cx="52.354" cy="24.4955" r="22.4568" fill="white"/>
+<circle cx="84.714" cy="44.1407" r="24.8207" fill="#DFDFDF"/>
+<circle cx="83.6753" cy="45.1793" r="24.8207" fill="white"/>
+<rect x="34.7503" y="42.5791" width="47.7789" height="27.1845" fill="white"/>
+<circle cx="30.0993" cy="43.772" r="25.4116" fill="#DFDFDF"/>
+<circle cx="31.0792" cy="44.5884" r="25.4116" fill="white"/>
+</g>
+<g filter="url(#filter3_d_71_259)">
+<circle cx="113.598" cy="62.8994" r="33.4529" fill="#DFDFDF"/>
+<circle cx="112.82" cy="64.4467" r="33.4529" fill="white"/>
+<circle cx="161.026" cy="93.7113" r="36.9743" fill="#DFDFDF"/>
+<circle cx="159.478" cy="95.2586" r="36.9743" fill="white"/>
+<rect x="86.597" y="91.3851" width="71.1741" height="40.4956" fill="white"/>
+<circle cx="80.3546" cy="92.831" r="37.8546" fill="#DFDFDF"/>
+<circle cx="81.1282" cy="94.3783" r="37.8546" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_71_259" x="49" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter1_d_71_259" x="113.79" y="1" width="102.21" height="70" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter2_d_71_259" x="0.68766" y="1" width="112.847" height="77" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+<filter id="filter3_d_71_259" x="38.5" y="29.4465" width="163.5" height="110.786" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_259"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_259" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/partly-cloud-rain.svg
+++ b/public/images/cloud_icons/partly-cloud-rain.svg
@@ -1,0 +1,89 @@
+<svg width="191" height="180" viewBox="0 0 191 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_222)">
+<path d="M92 0L103.012 8.63663L116.492 4.87171L123.361 17.0652L137.255 18.7452L138.935 32.6392L151.128 39.5083L147.363 52.9875L156 64L147.363 75.0125L151.128 88.4917L138.935 95.3608L137.255 109.255L123.361 110.935L116.492 123.128L103.012 119.363L92 128L80.9875 119.363L67.5083 123.128L60.6392 110.935L46.7452 109.255L45.0652 95.3608L32.8717 88.4917L36.6366 75.0125L28 64L36.6366 52.9875L32.8717 39.5083L45.0652 32.6392L46.7452 18.7452L60.6392 17.0652L67.5083 4.87171L80.9875 8.63663L92 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_222)">
+<circle cx="143.876" cy="59.2494" r="17.2494" fill="#DFDFDF"/>
+<circle cx="143.079" cy="60.0472" r="17.2494" fill="white"/>
+<circle cx="167.935" cy="75.137" r="19.0651" fill="#DFDFDF"/>
+<circle cx="167.137" cy="75.9349" r="19.0651" fill="white"/>
+<rect x="129.557" y="73.9376" width="36.6997" height="20.8809" fill="white"/>
+<circle cx="125.984" cy="74.8539" r="19.5191" fill="#DFDFDF"/>
+<circle cx="126.737" cy="75.4809" r="19.5191" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_222)">
+<circle cx="41.4111" cy="52.2494" r="17.2494" fill="#DFDFDF"/>
+<circle cx="40.6133" cy="53.0472" r="17.2494" fill="white"/>
+<circle cx="65.4695" cy="68.137" r="19.0651" fill="#DFDFDF"/>
+<circle cx="64.6717" cy="68.9349" r="19.0651" fill="white"/>
+<rect x="27.0916" y="66.9376" width="36.6997" height="20.8809" fill="white"/>
+<circle cx="23.5191" cy="67.8539" r="19.5191" fill="#DFDFDF"/>
+<circle cx="24.2717" cy="68.4809" r="19.5191" fill="white"/>
+</g>
+<g filter="url(#filter3_d_71_222)">
+<circle cx="72.0618" cy="67.966" r="28.966" fill="#DFDFDF"/>
+<circle cx="71.3887" cy="69.3057" r="28.966" fill="white"/>
+<circle cx="113.128" cy="94.6452" r="32.0151" fill="#DFDFDF"/>
+<circle cx="111.789" cy="95.9849" r="32.0151" fill="white"/>
+<rect x="48.6825" y="92.631" width="61.6278" height="35.0641" fill="white"/>
+<circle cx="43.2773" cy="93.8829" r="32.7773" fill="#DFDFDF"/>
+<circle cx="43.9472" cy="95.2227" r="32.7773" fill="white"/>
+<g filter="url(#filter4_d_71_222)">
+<rect x="100.953" y="133.57" width="7.01025" height="29.443" transform="rotate(-30 100.953 133.57)" fill="#28AFE9"/>
+<rect x="81.3239" y="146.188" width="7.01025" height="29.443" transform="rotate(-30 81.3239 146.188)" fill="#28AFE9"/>
+<rect x="52" y="136.594" width="7.01025" height="29.443" transform="rotate(-30 52 136.594)" fill="#28AFE9"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_71_222" x="24" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter1_d_71_222" x="102.465" y="42" width="88.5346" height="61" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter2_d_71_222" x="0" y="35" width="88.5346" height="61" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter3_d_71_222" x="6.5" y="39" width="142.643" height="140.687" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter4_d_71_222" x="48" y="130.065" width="77.7452" height="49.622" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/partly-cloudy-early-rain.svg
+++ b/public/images/cloud_icons/partly-cloudy-early-rain.svg
@@ -1,0 +1,55 @@
+<svg width="185" height="136" viewBox="0 0 185 136" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_222)">
+<path d="M109 0L120.012 8.63663L133.492 4.87171L140.361 17.0652L154.255 18.7452L155.935 32.6392L168.128 39.5083L164.363 52.9875L173 64L164.363 75.0125L168.128 88.4917L155.935 95.3608L154.255 109.255L140.361 110.935L133.492 123.128L120.012 119.363L109 128L97.9875 119.363L84.5083 123.128L77.6392 110.935L63.7452 109.255L62.0652 95.3608L49.8717 88.4917L53.6366 75.0125L45 64L53.6366 52.9875L49.8717 39.5083L62.0652 32.6392L63.7452 18.7452L77.6392 17.0652L84.5083 4.87171L97.9875 8.63663L109 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_222)">
+<circle cx="50.4507" cy="83.1897" r="21.6207" fill="#DFDFDF"/>
+<circle cx="49.9483" cy="84.1897" r="21.6207" fill="white"/>
+<circle cx="81.1034" cy="103.103" r="23.8966" fill="#DFDFDF"/>
+<circle cx="80.1034" cy="104.103" r="23.8966" fill="white"/>
+<rect x="33" y="101.6" width="46" height="26.1724" fill="white"/>
+<circle cx="28.9655" cy="102.534" r="24.4655" fill="#DFDFDF"/>
+<circle cx="29.4655" cy="103.534" r="24.4655" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_222)">
+<circle cx="152.353" cy="71.2505" r="11.459" fill="#DFDFDF"/>
+<circle cx="151.823" cy="71.7805" r="11.459" fill="white"/>
+<circle cx="168.335" cy="81.8048" r="12.6652" fill="#DFDFDF"/>
+<circle cx="167.805" cy="82.3348" r="12.6652" fill="white"/>
+<rect x="142.84" y="81.008" width="24.38" height="13.8714" fill="white"/>
+<circle cx="140.467" cy="81.6167" r="12.9667" fill="#DFDFDF"/>
+<circle cx="140.967" cy="82.0333" r="12.9667" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_71_222" x="41" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter1_d_71_222" x="0.5" y="61.569" width="108.5" height="74.431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter2_d_71_222" x="123.5" y="59.7916" width="61.5" height="43.2085" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/cloud_icons/partly-cloudy.svg
+++ b/public/images/cloud_icons/partly-cloudy.svg
@@ -1,0 +1,74 @@
+<svg width="191" height="136" viewBox="0 0 191 136" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_71_222)">
+<path d="M92 0L103.012 8.63663L116.492 4.87171L123.361 17.0652L137.255 18.7452L138.935 32.6392L151.128 39.5083L147.363 52.9875L156 64L147.363 75.0125L151.128 88.4917L138.935 95.3608L137.255 109.255L123.361 110.935L116.492 123.128L103.012 119.363L92 128L80.9875 119.363L67.5083 123.128L60.6392 110.935L46.7452 109.255L45.0652 95.3608L32.8717 88.4917L36.6366 75.0125L28 64L36.6366 52.9875L32.8717 39.5083L45.0652 32.6392L46.7452 18.7452L60.6392 17.0652L67.5083 4.87171L80.9875 8.63663L92 0Z" fill="#FFD43E"/>
+</g>
+<g filter="url(#filter1_d_71_222)">
+<circle cx="143.876" cy="59.2494" r="17.2494" fill="#DFDFDF"/>
+<circle cx="143.079" cy="60.0472" r="17.2494" fill="white"/>
+<circle cx="167.935" cy="75.137" r="19.0651" fill="#DFDFDF"/>
+<circle cx="167.137" cy="75.9349" r="19.0651" fill="white"/>
+<rect x="129.557" y="73.9376" width="36.6997" height="20.8809" fill="white"/>
+<circle cx="125.984" cy="74.8539" r="19.5191" fill="#DFDFDF"/>
+<circle cx="126.737" cy="75.4809" r="19.5191" fill="white"/>
+</g>
+<g filter="url(#filter2_d_71_222)">
+<circle cx="41.4111" cy="52.2494" r="17.2494" fill="#DFDFDF"/>
+<circle cx="40.6133" cy="53.0472" r="17.2494" fill="white"/>
+<circle cx="65.4695" cy="68.137" r="19.0651" fill="#DFDFDF"/>
+<circle cx="64.6717" cy="68.9349" r="19.0651" fill="white"/>
+<rect x="27.0916" y="66.9376" width="36.6997" height="20.8809" fill="white"/>
+<circle cx="23.5191" cy="67.8539" r="19.5191" fill="#DFDFDF"/>
+<circle cx="24.2717" cy="68.4809" r="19.5191" fill="white"/>
+</g>
+<g filter="url(#filter3_d_71_222)">
+<circle cx="72.0618" cy="67.966" r="28.966" fill="#DFDFDF"/>
+<circle cx="71.3887" cy="69.3057" r="28.966" fill="white"/>
+<circle cx="113.128" cy="94.6452" r="32.0151" fill="#DFDFDF"/>
+<circle cx="111.789" cy="95.9849" r="32.0151" fill="white"/>
+<rect x="48.6825" y="92.631" width="61.6278" height="35.0641" fill="white"/>
+<circle cx="43.2773" cy="93.8829" r="32.7773" fill="#DFDFDF"/>
+<circle cx="43.9472" cy="95.2227" r="32.7773" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_71_222" x="24" y="0" width="136" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter1_d_71_222" x="102.465" y="42" width="88.5346" height="61" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter2_d_71_222" x="0" y="35" width="88.5346" height="61" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+<filter id="filter3_d_71_222" x="6.5" y="39" width="142.643" height="97" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_71_222"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_71_222" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/server/constants/configs.json
+++ b/server/constants/configs.json
@@ -15,31 +15,36 @@
       "id": 0,
       "name": "Clear",
       "description": "Clear skies",
-      "oktas": 0
+      "oktas": 0,
+      "image": "../images/cloud_icons/clear.svg"
     },
     {
       "id": 1,
       "name": "Mostly Clear",
       "description": "Mostly clear with few clouds",
-      "oktas": 2
+      "oktas": 2,
+      "image": "../images/cloud_icons/mostly-clear.svg"
     },
     {
       "id": 2,
       "name": "Partly Cloudy",
       "description": "A mostly even mix of sun and clouds",
-      "oktas": 4
+      "oktas": 4,
+      "image": "../images/cloud_icons/partly-cloudy.svg"
     },
     {
       "id": 3,
       "name": "Mostly Cloudy",
       "description": "Mostly cloudy with some sun",
-      "oktas": 6
+      "oktas": 6,
+      "image": "../images/cloud_icons/mostly-cloudy.svg"
     },
     {
       "id": 4,
       "name": "Overcast",
       "description": "Cloudy skies",
-      "oktas": 8
+      "oktas": 8,
+      "image": "../images/cloud_icons/cloudy.svg"
     }
   ],
 

--- a/server/server.js
+++ b/server/server.js
@@ -15,8 +15,8 @@ const forecastLocations = require("./routes/forecastLocations.router")
 const userRouter = require("./routes/user.router")
 
 // Body parser middleware
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: true }))
 
 // Passport Session Configuration //
 app.use(sessionMiddleware);

--- a/server/strategies/user.strategy.js
+++ b/server/strategies/user.strategy.js
@@ -13,7 +13,12 @@ passport.deserializeUser((id, done) => {
 
   // Query returns BOTH the user AND user_settings
   const sqlQuery = `
-    SELECT *
+    SELECT
+      "user"."id",
+      "user_settings"."id" AS "user_settings_id",
+      "user"."email",
+      "user_settings"."metric",
+      "user_settings"."localization"
     FROM "user"
     JOIN "user_settings"
       ON "user".id = user_settings.user_id

--- a/src/components/ForecastHistory/DisplayForecastHistory.jsx
+++ b/src/components/ForecastHistory/DisplayForecastHistory.jsx
@@ -6,7 +6,6 @@ import { useSelector } from "react-redux"
 import NestedForecastHistory from "./NestedForecastHistory"
 
 // Import utility functions
-import buildWindSpeedString from "../Utilities/CreateWindSpeedString"
 import setForecastFieldsForDisplay from "../Utilities/FormatForecastFields"
 
 
@@ -57,7 +56,7 @@ export default function DisplayForecastHistory({ forecastHistoryObj, additionalF
           {forecastForDisplay.windString}
         </div>
         <div>
-          {forecastForDisplay.forecastCreationDate}
+          {forecastForDisplay.forecastCreationDateTime}
         </div>
         {(additionalForecastHistoryArray) ?
           <NestedForecastHistory

--- a/src/components/Forecasts/PreviousForecasts/DisplayFullPreviousForecasts.jsx
+++ b/src/components/Forecasts/PreviousForecasts/DisplayFullPreviousForecasts.jsx
@@ -1,0 +1,24 @@
+// Import utility functions
+import setForecastFieldsForDisplay from "../../Utilities/FormatForecastFields"
+
+
+// Component that will display a small version of the forecast
+// that can be selected by the user. When selected, that small window
+// will be used to populate the current forecast form.
+export default function DisplayFullPastForecast({ forecastValues }) {
+
+    // Get the forecast variables converted to workable string values
+    const forecast = setForecastFieldsForDisplay(forecastValues)
+
+    // Build the DOM element
+    return (
+        <div>
+            <p>{forecast.forecastCreationDateTime}</p>
+            <div>{forecast.cloudCover}</div>
+            <div>{forecast.pop}</div>
+            <div>{forecast.highTemp}</div>
+            <div>{forecast.lowTemp}</div>
+            <div>{forecast.windString}</div>
+        </div>
+    )
+}

--- a/src/components/Forecasts/PreviousForecasts/DisplayVariableFromPreviousForecast.jsx
+++ b/src/components/Forecasts/PreviousForecasts/DisplayVariableFromPreviousForecast.jsx
@@ -1,0 +1,13 @@
+// Import the core libraries and functions
+import { useSelector } from "react-redux"
+
+
+// Component that shows the past day values for an individual
+// input for the current forecast input
+export default function DisplayVariableFromPreviousForecast() {
+
+    const forecastFieldHistory = useSelector(store => store.userForecastHistory.userForecastHistory)
+
+    // Buid the DOM elements
+    return (<></>)
+}

--- a/src/components/Utilities/FormatForecastFields.js
+++ b/src/components/Utilities/FormatForecastFields.js
@@ -41,7 +41,11 @@ function setForecastFieldsForDisplay (forecastObj) {
     windDirection: windDirectionList.find(wind => wind.id === forecastObj.wind_direction).abbreviation,
 
     // String stating when the forecast was created
-    forecastCreationDate: format(new Date(forecastObj.created_on), "MMM dd, yyyy @ h:mmbb")
+    forecastCreationDateTime: format(new Date(forecastObj.created_on), "MMM dd, yyyy - h:mm aaa"),
+    // Date string value from when the forecast was created
+    forecastCreationDate: format(new Date(forecastObj.created_on), "MMM dd, yyyy"),
+    // Time string value from when the forecast was created
+    forecastCreationTime: format(new Date(forecastObj.created_on), "h:mm aaa")
   }
 
   // Create a string that contains all the important information regarding wind fields

--- a/wxStationListToSqlFile.js
+++ b/wxStationListToSqlFile.js
@@ -60,13 +60,11 @@ VALUES
     }  
   }
 
-  console.log(sqlQuery)
-
   // Find the last comma in this giant string and replace it with the closing
   // values for our SQL insert statement
   const lastCommaIndex = sqlQuery.lastIndexOf(',')
   sqlQuery = sqlQuery.substring(0, lastCommaIndex) + `;`
-  console.log(sqlQuery)
+
 
   // Write to the SQL file
   fs.writeFile(


### PR DESCRIPTION
Past user forecasts now show under the current forecast window. Number of forecasts are currently hard-coded and limited to four (4), but could be easily changed.

Clicking any of those previous forecasts allow the user to move those values into the current forecast input form.

Also, added some custom SVG weather icons into the `/public` folder (I made them in Figma! Was quite easy!).
* Updated the `config` file to reflect those images